### PR TITLE
Fix GitHub Actions version deprecations

### DIFF
--- a/.github/workflows/import-publications.yml
+++ b/.github/workflows/import-publications.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
       - name: Create Pull Request
         # Set ID for `Check outputs` stage
         id: cpr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           commit-message: 'content: import publications from Bibtex'
           title: Hugo Blox Builder - Import latest publications

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -44,7 +44,7 @@ jobs:
           ${{ runner.os }}-hugomod-
     - name: Setup Pages
       id: pages
-      uses: actions/configure-pages@v3
+      uses: actions/configure-pages@v4
     - name: Build with Hugo
       env:
         HUGO_ENVIRONMENT: production
@@ -69,4 +69,4 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v3


### PR DESCRIPTION
## Summary
- update GitHub Pages actions to the latest versions
- update publication importer actions

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687b0376f0e0833382e7bdeb6dc4e64a