### PR TITLE
Fix Pages artifact step using v4 action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,9 +54,11 @@ jobs:
     - name: Generate Pagefind search index
       run: npx pagefind --site "public"
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
+        name: github-pages
         path: ./public
+        retention-days: 1
 
   # Deploy website to GitHub Pages hosting
   deploy:


### PR DESCRIPTION
## Summary
- avoid deprecated artifact action by using `actions/upload-artifact@v4`

## Testing
- `hugo --gc --minify` *(fails: command not found)*
- `apt-get update` *(fails: blocked by environment)*

------
https://chatgpt.com/codex/tasks/task_e_687b0c6f95588333b9cf219226042fad