### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,11 +54,9 @@ jobs:
     - name: Generate Pagefind search index
       run: npx pagefind --site "public"
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-pages-artifact@v2
       with:
-        name: github-pages
         path: ./public
-        retention-days: 1
 
   # Deploy website to GitHub Pages hosting
   deploy:


### PR DESCRIPTION
## Summary
- fix GitHub Pages workflow to upload Pages artifact using `actions/upload-pages-artifact`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687b0f4a75e483339b936e2fbea6485e